### PR TITLE
Add tenant_id to selection_history for fair cross-tenant moves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,39 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [2026-06-22] - Tenant-Scoped Selection History
+
+### Added
+
+- `tenant_id` column on `selection_history` for per-tenant fairness
+- `move` command in `manage_users.py` to relocate users between
+  tenants
+- Migration script `migrate_selection_history_tenant.py`
+- Index on `(tenant_id, selected_date)` for query performance
+
+### Changed
+
+- Fairness algorithm now scopes `recent_selections`,
+  `total_selections`, and "days since last selected" per tenant
+- `get_last_working_day_catcher` queries `selection_history.tenant_id`
+  directly instead of JOINing through `user`
+- `user_statistics.py` groups stats by `selection_history.tenant_id`
+- `manage_vacations.py list-users` derives last selected date from
+  history instead of `user.last_chosen`
+- Takeover app uses `selection_history.tenant_id` for scoping
+
+### Removed
+
+- `user.last_chosen` column (replaced by
+  `MAX(selected_date) FROM selection_history WHERE tenant_id = ?`)
+
+### Migration Notes
+
+Run `uv run migrate_selection_history_tenant.py` before deploying.
+The migration backfills `tenant_id` from the user's current tenant.
+If any user has already moved between tenants, manually fix their
+old `selection_history` rows afterward.
+
 ## [2026-05-29d] - CI Fix
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -144,6 +144,9 @@ uv run manage_users.py add "john.doe@example.com" "Team Name" \
 uv run manage_users.py update "john.doe@example.com" \
   --weekdays "0,1,2"
 
+# Move user to a different tenant
+uv run manage_users.py move "john.doe@example.com" "New Team"
+
 # Set display name for iCal matching
 uv run manage_users.py set-display-name \
   "john.doe@example.com" "Johnny"
@@ -285,6 +288,9 @@ uv run migrate_takeover.py
 
 # Slack channel ID per tenant (REQUIRED: set channel IDs after running)
 uv run migrate_channel_id.py
+
+# Tenant-scoped selection history + remove user.last_chosen
+uv run migrate_selection_history_tenant.py
 ```
 
 > **Warning:** After running `migrate_channel_id.py`, you must set
@@ -317,13 +323,12 @@ VACATION_RETENTION_DAYS=90
 
 The application uses SQLite with the following tables:
 
-- **user**: `id`, `mail`, `weekdays`, `last_chosen`, `tenant_id`,
-  `display_name`
+- **user**: `id`, `mail`, `weekdays`, `tenant_id`, `display_name`
 - **tenants**: `id`, `name`, `location`, `webhook_url`, `active`,
   `ical_url`, `takeover_secret`, `slack_channel_id`, `created_at`
 - **vacation**: `id`, `user_id`, `start_date`, `end_date`, `source`,
   `last_synced`, `ical_event_uid`
-- **selection_history**: `id`, `user_id`, `selected_date`
+- **selection_history**: `id`, `user_id`, `selected_date`, `tenant_id`
 - **vacation_sync_log**: `id`, `tenant_id`, `sync_timestamp`,
   `status`, `events_processed`, `users_matched`, `error_message`
 - **takeover_log**: `id`, `tenant_id`, `takeover_date`,

--- a/catcher.py
+++ b/catcher.py
@@ -411,7 +411,11 @@ def trigger_slack(
         logging.info(f"[DRY RUN] Would send Slack notification to: {mail}")
         return True
 
-    data: Dict[str, str] = {"uid": mail, "registration_url": registration_url, "channel_id": channel_id}
+    data: Dict[str, str] = {
+        "uid": mail,
+        "registration_url": registration_url,
+        "channel_id": channel_id,
+    }
     headers: Dict[str, str] = {"Content-type": "application/json"}
 
     if not webhook_url:
@@ -539,10 +543,9 @@ def get_last_working_day_catcher(
             if tenant_id:
                 cursor.execute(
                     """
-                    SELECT sh.user_id
-                    FROM selection_history sh
-                    JOIN user u ON u.id = sh.user_id
-                    WHERE sh.selected_date = ? AND u.tenant_id = ?
+                    SELECT user_id
+                    FROM selection_history
+                    WHERE selected_date = ? AND tenant_id = ?
                 """,
                     (check_date.isoformat(), tenant_id),
                 )
@@ -568,7 +571,10 @@ def get_last_working_day_catcher(
 
 
 def get_recent_selection_count(
-    conn: sqlite3.Connection, user_id: int, days: int = LOOKBACK_DAYS
+    conn: sqlite3.Connection,
+    user_id: int,
+    tenant_id: int = None,
+    days: int = LOOKBACK_DAYS,
 ) -> int:
     """
     Get the number of times a user was selected in the last N days.
@@ -576,6 +582,7 @@ def get_recent_selection_count(
     Args:
         conn: Database connection
         user_id: User ID to check
+        tenant_id: Tenant ID to filter by
         days: Number of days to look back
 
     Returns:
@@ -586,15 +593,27 @@ def get_recent_selection_count(
             datetime.date.today() - datetime.timedelta(days=days)
         ).isoformat()
         cursor = conn.cursor()
-        cursor.execute(
-            """
-            SELECT COUNT(*) 
-            FROM selection_history 
-            WHERE user_id = ? 
-              AND selected_date >= ?
-        """,
-            (user_id, cutoff_date),
-        )
+        if tenant_id:
+            cursor.execute(
+                """
+                SELECT COUNT(*) 
+                FROM selection_history 
+                WHERE user_id = ? 
+                  AND tenant_id = ?
+                  AND selected_date >= ?
+            """,
+                (user_id, tenant_id, cutoff_date),
+            )
+        else:
+            cursor.execute(
+                """
+                SELECT COUNT(*) 
+                FROM selection_history 
+                WHERE user_id = ? 
+                  AND selected_date >= ?
+            """,
+                (user_id, cutoff_date),
+            )
 
         return cursor.fetchone()[0]
     except sqlite3.Error as e:
@@ -681,12 +700,11 @@ def add_tie_breaking_logic(weighted_users: List[Dict]) -> List[Dict]:
             # No tie to break
             result.extend(users)
         else:
-            # Break ties by last_chosen date, then by email
+            # Break ties by last_selected date, then by email
             users_sorted = sorted(
                 users,
                 key=lambda wu: (
-                    wu["user"]["last_chosen"]
-                    or "1900-01-01",  # Never selected = oldest
+                    wu["last_selected"] or "1900-01-01",  # Never selected = oldest
                     wu["user"]["mail"],  # Alphabetical as final tie-breaker
                 ),
             )
@@ -705,7 +723,7 @@ def add_tie_breaking_logic(weighted_users: List[Dict]) -> List[Dict]:
 
 def calculate_user_weight(
     user_id: int,
-    last_chosen: Optional[str],
+    last_selected: Optional[str],
     last_working_day_catcher_id: Optional[int],
     recent_selections: int,
     total_selections: int,
@@ -717,7 +735,7 @@ def calculate_user_weight(
 
     Args:
         user_id: User ID
-        last_chosen: Last chosen date (ISO format) or None
+        last_selected: Last selected date (ISO format) or None
         last_working_day_catcher_id: User ID of the last working day's catcher
         recent_selections: Number of recent selections
         total_selections: Total number of selections (all time)
@@ -730,9 +748,9 @@ def calculate_user_weight(
     weight = BASE_WEIGHT
 
     # Add weight based on days since last selection (non-linear growth)
-    if last_chosen:
+    if last_selected:
         try:
-            last_date = datetime.datetime.strptime(last_chosen, "%Y-%m-%d").date()
+            last_date = datetime.datetime.strptime(last_selected, "%Y-%m-%d").date()
             days_since = (datetime.date.today() - last_date).days
             # Use square root for gradual acceleration, then square for stronger acceleration after 10 days
             if days_since <= 10:
@@ -812,7 +830,7 @@ def find_next_catcher(
                     SELECT u.mail 
                     FROM user u
                     JOIN selection_history sh ON u.id = sh.user_id
-                    WHERE sh.selected_date = ? AND u.tenant_id = ?
+                    WHERE sh.selected_date = ? AND sh.tenant_id = ?
                 """,
                     (today, tenant_id),
                 )
@@ -839,7 +857,7 @@ def find_next_catcher(
             if tenant_id:
                 cur.execute(
                     """
-                    SELECT id, mail, last_chosen
+                    SELECT id, mail
                     FROM user 
                     WHERE weekdays LIKE ? AND tenant_id = ?
                 """,
@@ -848,7 +866,7 @@ def find_next_catcher(
             else:
                 cur.execute(
                     """
-                    SELECT id, mail, last_chosen
+                    SELECT id, mail
                     FROM user 
                     WHERE weekdays LIKE ?
                 """,
@@ -883,12 +901,31 @@ def find_next_catcher(
 
             # Get total selection counts for balance calculation
             total_selections_map = {}
+            last_selected_map = {}
             for user in available_users:
-                cur.execute(
-                    "SELECT COUNT(*) FROM selection_history WHERE user_id = ?",
-                    (user["id"],),
-                )
+                if tenant_id:
+                    cur.execute(
+                        "SELECT COUNT(*) FROM selection_history WHERE user_id = ? AND tenant_id = ?",
+                        (user["id"], tenant_id),
+                    )
+                else:
+                    cur.execute(
+                        "SELECT COUNT(*) FROM selection_history WHERE user_id = ?",
+                        (user["id"],),
+                    )
                 total_selections_map[user["id"]] = cur.fetchone()[0]
+
+                if tenant_id:
+                    cur.execute(
+                        "SELECT MAX(selected_date) FROM selection_history WHERE user_id = ? AND tenant_id = ?",
+                        (user["id"], tenant_id),
+                    )
+                else:
+                    cur.execute(
+                        "SELECT MAX(selected_date) FROM selection_history WHERE user_id = ?",
+                        (user["id"],),
+                    )
+                last_selected_map[user["id"]] = cur.fetchone()[0]
 
             # Calculate average total selections
             avg_total_selections = (
@@ -898,11 +935,14 @@ def find_next_catcher(
             )
 
             for user in available_users:
-                recent_selections = get_recent_selection_count(conn, user["id"])
+                recent_selections = get_recent_selection_count(
+                    conn, user["id"], tenant_id
+                )
                 total_selections = total_selections_map[user["id"]]
+                last_selected = last_selected_map[user["id"]]
                 weight = calculate_user_weight(
                     user["id"],
-                    user["last_chosen"],
+                    last_selected,
                     last_working_day_catcher_id,
                     recent_selections,
                     total_selections,
@@ -916,6 +956,7 @@ def find_next_catcher(
                         "weight": weight,
                         "recent_selections": recent_selections,
                         "total_selections": total_selections,
+                        "last_selected": last_selected,
                         "is_yesterday": user["id"] == last_working_day_catcher_id,
                     }
                 )
@@ -948,7 +989,7 @@ def find_next_catcher(
                     logging.info(
                         f"  {user['mail']}: weight={wu['weight']:.3f}, "
                         f"probability={probability:.1f}%, "
-                        f"last_chosen={user['last_chosen']}, "
+                        f"last_selected={wu['last_selected']}, "
                         f"recent_selections={wu['recent_selections']}, "
                         f"total_selections={wu['total_selections']}, "
                         f"is_last_working_day={wu['is_yesterday']}{tie_info}"
@@ -969,14 +1010,8 @@ def find_next_catcher(
             else:
                 # Record the selection in history
                 cur.execute(
-                    "INSERT INTO selection_history (user_id, selected_date) VALUES (?, ?)",
-                    (selected_user["id"], today),
-                )
-
-                # Update the last_chosen date for backward compatibility
-                cur.execute(
-                    "UPDATE user SET last_chosen = ? WHERE id = ?",
-                    (today, selected_user["id"]),
+                    "INSERT INTO selection_history (user_id, selected_date, tenant_id) VALUES (?, ?, ?)",
+                    (selected_user["id"], today, tenant_id),
                 )
 
                 conn.commit()

--- a/manage_users.py
+++ b/manage_users.py
@@ -27,8 +27,11 @@ def get_db_path(args):
 
 def validate_weekdays(value):
     """Validate weekdays is a comma-separated list of digits 0-6."""
-    if not re.match(r'^[0-6](,[0-6])*$', value):
-        print("Error: weekdays must be comma-separated digits 0-6 (0=Sun, 1=Mon, ..., 6=Sat)", file=sys.stderr)
+    if not re.match(r"^[0-6](,[0-6])*$", value):
+        print(
+            "Error: weekdays must be comma-separated digits 0-6 (0=Sun, 1=Mon, ..., 6=Sat)",
+            file=sys.stderr,
+        )
         sys.exit(1)
 
 
@@ -50,10 +53,12 @@ def cmd_list(args):
         FROM user u
         LEFT JOIN tenants t ON u.tenant_id = t.id
     """
-    
+
     if args.tenant:
         query += " WHERE t.name = ? OR t.id = ?"
-        cursor = conn.execute(query, (args.tenant, args.tenant if args.tenant.isdigit() else -1))
+        cursor = conn.execute(
+            query, (args.tenant, args.tenant if args.tenant.isdigit() else -1)
+        )
     else:
         query += " ORDER BY u.id"
         cursor = conn.execute(query)
@@ -89,8 +94,7 @@ def cmd_set_display_name(args):
     display_name = args.display_name if args.display_name else None
 
     conn.execute(
-        "UPDATE user SET display_name = ? WHERE id = ?",
-        (display_name, user_id)
+        "UPDATE user SET display_name = ? WHERE id = ?", (display_name, user_id)
     )
     conn.commit()
     conn.close()
@@ -140,7 +144,7 @@ def cmd_add(args):
     # Get tenant ID
     cursor = conn.execute(
         "SELECT id FROM tenants WHERE name = ? OR id = ?",
-        (args.tenant, args.tenant if args.tenant.isdigit() else -1)
+        (args.tenant, args.tenant if args.tenant.isdigit() else -1),
     )
     tenant_row = cursor.fetchone()
     if not tenant_row:
@@ -154,7 +158,7 @@ def cmd_add(args):
     validate_weekdays(weekdays)
     conn.execute(
         "INSERT INTO user (mail, weekdays, tenant_id, display_name) VALUES (?, ?, ?, ?)",
-        (args.email, weekdays, tenant_id, args.display_name)
+        (args.email, weekdays, tenant_id, args.display_name),
     )
     conn.commit()
     conn.close()
@@ -186,7 +190,7 @@ def cmd_update(args):
     if args.tenant:
         cursor = conn.execute(
             "SELECT id FROM tenants WHERE name = ? OR id = ?",
-            (args.tenant, args.tenant if args.tenant.isdigit() else -1)
+            (args.tenant, args.tenant if args.tenant.isdigit() else -1),
         )
         tenant_row = cursor.fetchone()
         if not tenant_row:
@@ -233,10 +237,50 @@ def cmd_delete(args):
     print(f"User '{email}' deleted successfully")
 
 
-def main():
-    parser = argparse.ArgumentParser(
-        description="Manage users for Catcher of the Day"
+def cmd_move(args):
+    """Move a user to a different tenant."""
+    conn = get_db_connection(get_db_path(args))
+
+    user = get_user_by_id_or_email(conn, args.identifier)
+    if not user:
+        print(f"Error: User '{args.identifier}' not found", file=sys.stderr)
+        conn.close()
+        sys.exit(1)
+
+    user_id, email, _, current_tenant_id = user
+
+    # Resolve target tenant
+    cursor = conn.execute(
+        "SELECT id, name FROM tenants WHERE name = ? OR id = ?",
+        (args.tenant, args.tenant if args.tenant.isdigit() else -1),
     )
+    tenant_row = cursor.fetchone()
+    if not tenant_row:
+        print(f"Error: Tenant '{args.tenant}' not found", file=sys.stderr)
+        conn.close()
+        sys.exit(1)
+
+    new_tenant_id, new_tenant_name = tenant_row[0], tenant_row[1]
+
+    if new_tenant_id == current_tenant_id:
+        print(f"User '{email}' is already in tenant '{new_tenant_name}'")
+        conn.close()
+        return
+
+    # Get current tenant name for logging
+    cursor = conn.execute("SELECT name FROM tenants WHERE id = ?", (current_tenant_id,))
+    old_tenant_row = cursor.fetchone()
+    old_tenant_name = old_tenant_row[0] if old_tenant_row else "(no tenant)"
+
+    conn.execute("UPDATE user SET tenant_id = ? WHERE id = ?", (new_tenant_id, user_id))
+    conn.commit()
+    conn.close()
+
+    print(f"User '{email}' moved from '{old_tenant_name}' to '{new_tenant_name}'")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Manage users for Catcher of the Day")
     parser.add_argument("--db", help="Database path (overrides DB_PATH env var)")
 
     subparsers = parser.add_subparsers(dest="command", required=True)
@@ -250,15 +294,21 @@ def main():
     show_parser.add_argument("identifier", help="User ID or email")
 
     # Set display name command
-    set_name_parser = subparsers.add_parser("set-display-name", help="Set display name for a user")
+    set_name_parser = subparsers.add_parser(
+        "set-display-name", help="Set display name for a user"
+    )
     set_name_parser.add_argument("identifier", help="User ID or email")
-    set_name_parser.add_argument("display_name", help="Display name/nickname (use empty string to clear)")
+    set_name_parser.add_argument(
+        "display_name", help="Display name/nickname (use empty string to clear)"
+    )
 
     # Add command
     add_parser = subparsers.add_parser("add", help="Add a new user")
     add_parser.add_argument("email", help="User email address")
     add_parser.add_argument("tenant", help="Tenant name or ID")
-    add_parser.add_argument("--weekdays", help="Available weekdays (default: 1,2,3,4,5 for Mon-Fri)")
+    add_parser.add_argument(
+        "--weekdays", help="Available weekdays (default: 1,2,3,4,5 for Mon-Fri)"
+    )
     add_parser.add_argument("--display-name", help="Display name/nickname")
 
     # Update command
@@ -271,6 +321,13 @@ def main():
     # Delete command
     delete_parser = subparsers.add_parser("delete", help="Delete a user")
     delete_parser.add_argument("identifier", help="User ID or email")
+
+    # Move command
+    move_parser = subparsers.add_parser(
+        "move", help="Move a user to a different tenant"
+    )
+    move_parser.add_argument("identifier", help="User ID or email")
+    move_parser.add_argument("tenant", help="Target tenant name or ID")
 
     args = parser.parse_args()
 
@@ -287,6 +344,8 @@ def main():
         cmd_update(args)
     elif args.command == "delete":
         cmd_delete(args)
+    elif args.command == "move":
+        cmd_move(args)
 
 
 if __name__ == "__main__":

--- a/manage_vacations.py
+++ b/manage_vacations.py
@@ -59,9 +59,12 @@ def list_users():
             cursor = conn.cursor()
             cursor.execute(
                 """
-                SELECT u.id, u.mail, u.weekdays, u.last_chosen, t.name as tenant_name
+                SELECT u.id, u.mail, u.weekdays, t.name as tenant_name,
+                       MAX(sh.selected_date) as last_selected
                 FROM user u
                 LEFT JOIN tenants t ON u.tenant_id = t.id
+                LEFT JOIN selection_history sh ON u.id = sh.user_id AND sh.tenant_id = u.tenant_id
+                GROUP BY u.id
                 ORDER BY u.mail
                 """
             )
@@ -74,14 +77,14 @@ def list_users():
             print("\nUsers:")
             print("-" * 95)
             print(
-                f"{'ID':<5} {'Email':<30} {'Tenant':<20} {'Weekdays':<10} {'Last Chosen':<12}"
+                f"{'ID':<5} {'Email':<30} {'Tenant':<20} {'Weekdays':<10} {'Last Selected':<12}"
             )
             print("-" * 95)
 
             for user in users:
                 tenant_name = user["tenant_name"] or "No Tenant"
                 print(
-                    f"{user['id']:<5} {user['mail']:<30} {tenant_name:<20} {user['weekdays']:<10} {user['last_chosen'] or 'Never':<12}"
+                    f"{user['id']:<5} {user['mail']:<30} {tenant_name:<20} {user['weekdays']:<10} {user['last_selected'] or 'Never':<12}"
                 )
     except sqlite3.Error as e:
         logging.error(f"Error listing users: {e}")
@@ -324,7 +327,15 @@ def check_vacation_overlap(
                     (start_date >= ? AND end_date <= ?)
                 )
             """,
-                (user_id, end_date, start_date, end_date, start_date, start_date, end_date),
+                (
+                    user_id,
+                    end_date,
+                    start_date,
+                    end_date,
+                    start_date,
+                    start_date,
+                    end_date,
+                ),
             )
             overlapping = cursor.fetchall()
 
@@ -336,7 +347,10 @@ def check_vacation_overlap(
                     else:
                         dates.append(f"{v['start_date']} to {v['end_date']}")
                 noun = "vacation" if len(dates) == 1 else "vacations"
-                return True, f"This vacation overlaps with your existing {noun}: {', '.join(dates)}"
+                return (
+                    True,
+                    f"This vacation overlaps with your existing {noun}: {', '.join(dates)}",
+                )
 
             return False, ""
     except Exception as e:
@@ -374,7 +388,10 @@ def check_duplicate_vacation(
             if result["count"] > 0:
                 if start_date == end_date:
                     return True, f"You already have a vacation on {start_date}"
-                return True, f"You already have a vacation from {start_date} to {end_date}"
+                return (
+                    True,
+                    f"You already have a vacation from {start_date} to {end_date}",
+                )
 
             return False, ""
     except Exception as e:

--- a/migrate_selection_history_tenant.py
+++ b/migrate_selection_history_tenant.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env -S uv run --script
+
+# /// script
+# dependencies = [
+#    "python-dotenv>=1.0.0",
+# ]
+# ///
+
+"""
+Migration script to add tenant_id to selection_history and remove user.last_chosen.
+
+This script:
+1. Adds tenant_id column to selection_history (NOT NULL, FK to tenants)
+2. Backfills tenant_id from current user.tenant_id
+3. Adds index on (tenant_id, selected_date)
+4. Drops user.last_chosen column
+"""
+
+import logging
+import sqlite3
+import sys
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+from db import DATABASE_PATH, get_db_connection
+
+load_dotenv()
+
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
+)
+
+
+def has_column(cursor, table, column):
+    """Check if a column exists in a table."""
+    cursor.execute(f"PRAGMA table_info({table})")
+    return any(row[1] == column for row in cursor.fetchall())
+
+
+def step_add_tenant_id(cursor):
+    """Add tenant_id column and backfill from user.tenant_id."""
+    if has_column(cursor, "selection_history", "tenant_id"):
+        logging.info("selection_history.tenant_id already exists, skipping")
+        return
+
+    logging.info("Adding tenant_id column to selection_history...")
+
+    # Add as nullable first so we can backfill
+    cursor.execute("ALTER TABLE selection_history ADD COLUMN tenant_id INTEGER")
+
+    # Backfill from user.tenant_id
+    cursor.execute("""
+        UPDATE selection_history
+        SET tenant_id = (SELECT tenant_id FROM user WHERE user.id = selection_history.user_id)
+    """)
+
+    # Check for any NULLs (orphaned records)
+    cursor.execute("SELECT COUNT(*) FROM selection_history WHERE tenant_id IS NULL")
+    null_count = cursor.fetchone()[0]
+    if null_count > 0:
+        logging.warning(
+            f"{null_count} selection_history rows have no matching user, "
+            "deleting orphaned records"
+        )
+        cursor.execute("DELETE FROM selection_history WHERE tenant_id IS NULL")
+
+    logging.info("Backfill complete")
+
+
+def step_enforce_not_null(cursor):
+    """Recreate table to enforce NOT NULL and FK on tenant_id."""
+    # Check if already NOT NULL by inspecting schema
+    cursor.execute(
+        "SELECT sql FROM sqlite_master WHERE type='table' AND name='selection_history'"
+    )
+    schema = cursor.fetchone()[0]
+    if "tenant_id INTEGER NOT NULL" in schema:
+        logging.info("tenant_id already NOT NULL, skipping table rebuild")
+        return
+
+    logging.info("Rebuilding selection_history to enforce NOT NULL on tenant_id...")
+
+    cursor.execute("""
+        CREATE TABLE selection_history_new (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INTEGER NOT NULL,
+            selected_date DATE NOT NULL,
+            tenant_id INTEGER NOT NULL,
+            FOREIGN KEY (user_id) REFERENCES user(id),
+            FOREIGN KEY (tenant_id) REFERENCES tenants(id)
+        )
+    """)
+
+    cursor.execute("""
+        INSERT INTO selection_history_new (id, user_id, selected_date, tenant_id)
+        SELECT id, user_id, selected_date, tenant_id FROM selection_history
+    """)
+
+    cursor.execute("DROP TABLE selection_history")
+    cursor.execute("ALTER TABLE selection_history_new RENAME TO selection_history")
+
+    logging.info("Table rebuilt with NOT NULL constraint")
+
+
+def step_create_indexes(cursor):
+    """Create indexes on the new table."""
+    cursor.execute("""
+        SELECT name FROM sqlite_master
+        WHERE type='index' AND name='idx_selection_history_tenant_date'
+    """)
+    if cursor.fetchone():
+        logging.info("Index idx_selection_history_tenant_date already exists")
+    else:
+        logging.info("Creating index on (tenant_id, selected_date)...")
+        cursor.execute("""
+            CREATE INDEX idx_selection_history_tenant_date
+            ON selection_history(tenant_id, selected_date)
+        """)
+
+    # Recreate original indexes (lost during table rebuild)
+    cursor.execute("""
+        SELECT name FROM sqlite_master
+        WHERE type='index' AND name='idx_selection_history_user_date'
+    """)
+    if not cursor.fetchone():
+        cursor.execute("""
+            CREATE INDEX idx_selection_history_user_date
+            ON selection_history(user_id, selected_date)
+        """)
+
+    cursor.execute("""
+        SELECT name FROM sqlite_master
+        WHERE type='index' AND name='idx_selection_history_date'
+    """)
+    if not cursor.fetchone():
+        cursor.execute("""
+            CREATE INDEX idx_selection_history_date
+            ON selection_history(selected_date)
+        """)
+
+
+def step_drop_last_chosen(cursor):
+    """Drop the last_chosen column from user table."""
+    if not has_column(cursor, "user", "last_chosen"):
+        logging.info("user.last_chosen already removed, skipping")
+        return
+
+    logging.info("Dropping user.last_chosen column...")
+    cursor.execute("ALTER TABLE user DROP COLUMN last_chosen")
+    logging.info("user.last_chosen removed")
+
+
+def main():
+    """Run the migration."""
+    if not Path(DATABASE_PATH).exists():
+        logging.error(f"Database file {DATABASE_PATH} not found")
+        sys.exit(1)
+
+    try:
+        with get_db_connection() as conn:
+            cursor = conn.cursor()
+
+            logging.info("Starting selection_history tenant migration...")
+
+            step_add_tenant_id(cursor)
+            step_enforce_not_null(cursor)
+            step_create_indexes(cursor)
+            step_drop_last_chosen(cursor)
+
+            conn.commit()
+            logging.info("Migration completed successfully!")
+
+    except sqlite3.Error as e:
+        logging.error(f"Database error during migration: {e}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/schema.sql
+++ b/schema.sql
@@ -17,7 +17,6 @@ CREATE TABLE IF NOT EXISTS user (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     mail VARCHAR(50) UNIQUE NOT NULL,
     weekdays VARCHAR(10),
-    last_chosen DATE,
     tenant_id INTEGER REFERENCES tenants(id),
     display_name VARCHAR(100)
 );
@@ -38,7 +37,9 @@ CREATE TABLE IF NOT EXISTS selection_history (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     user_id INTEGER NOT NULL,
     selected_date DATE NOT NULL,
-    FOREIGN KEY (user_id) REFERENCES user(id)
+    tenant_id INTEGER NOT NULL,
+    FOREIGN KEY (user_id) REFERENCES user(id),
+    FOREIGN KEY (tenant_id) REFERENCES tenants(id)
 );
 
 CREATE TABLE IF NOT EXISTS vacation_sync_log (
@@ -63,3 +64,5 @@ CREATE INDEX IF NOT EXISTS idx_selection_history_date
     ON selection_history(selected_date);
 CREATE INDEX IF NOT EXISTS idx_selection_history_user
     ON selection_history(user_id);
+CREATE INDEX IF NOT EXISTS idx_selection_history_tenant_date
+    ON selection_history(tenant_id, selected_date);

--- a/takeover_app.py
+++ b/takeover_app.py
@@ -103,8 +103,7 @@ def takeover():
 
         # Check if a takeover already happened today for this tenant
         existing = conn.execute(
-            "SELECT user_id FROM selection_history WHERE selected_date = ? AND user_id IN "
-            "(SELECT id FROM user WHERE tenant_id = ?)",
+            "SELECT user_id FROM selection_history WHERE selected_date = ? AND tenant_id = ?",
             (today, tenant_id),
         ).fetchone()
         if existing and existing[0] == user[0]:
@@ -119,34 +118,15 @@ def takeover():
                 message="A takeover has already been registered today."
             ), 409
 
-        # Find the previous catcher and reset their last_chosen
-        prev = conn.execute(
-            "SELECT user_id FROM selection_history WHERE selected_date = ? AND user_id IN "
-            "(SELECT id FROM user WHERE tenant_id = ?)",
-            (today, tenant_id),
-        ).fetchone()
-        if prev:
-            prior = conn.execute(
-                "SELECT selected_date FROM selection_history "
-                "WHERE user_id = ? AND selected_date < ? ORDER BY selected_date DESC LIMIT 1",
-                (prev[0], today),
-            ).fetchone()
-            conn.execute(
-                "UPDATE user SET last_chosen = ? WHERE id = ?",
-                (prior[0] if prior else None, prev[0]),
-            )
-
         # Replace today's selection_history entry
         conn.execute(
-            "DELETE FROM selection_history WHERE selected_date = ? AND user_id IN "
-            "(SELECT id FROM user WHERE tenant_id = ?)",
+            "DELETE FROM selection_history WHERE selected_date = ? AND tenant_id = ?",
             (today, tenant_id),
         )
         conn.execute(
-            "INSERT INTO selection_history (user_id, selected_date) VALUES (?, ?)",
-            (user[0], today),
+            "INSERT INTO selection_history (user_id, selected_date, tenant_id) VALUES (?, ?, ?)",
+            (user[0], today, tenant_id),
         )
-        conn.execute("UPDATE user SET last_chosen = ? WHERE id = ?", (today, user[0]))
         conn.execute(
             "INSERT INTO takeover_log (tenant_id, takeover_date, new_user_id) VALUES (?, ?, ?)",
             (tenant_id, today, user[0]),

--- a/tests/test_catcher.py
+++ b/tests/test_catcher.py
@@ -39,7 +39,6 @@ def db(tmp_path):
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             mail VARCHAR(50) UNIQUE NOT NULL,
             weekdays VARCHAR(10),
-            last_chosen DATE,
             tenant_id INTEGER REFERENCES tenants(id),
             display_name VARCHAR(100)
         );
@@ -57,7 +56,9 @@ def db(tmp_path):
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             user_id INTEGER NOT NULL,
             selected_date DATE NOT NULL,
-            FOREIGN KEY (user_id) REFERENCES user(id)
+            tenant_id INTEGER NOT NULL,
+            FOREIGN KEY (user_id) REFERENCES user(id),
+            FOREIGN KEY (tenant_id) REFERENCES tenants(id)
         );
     """)
 
@@ -73,12 +74,12 @@ def db(tmp_path):
 
     # Seed users for Team Alpha (tenant_id=1)
     conn.execute(
-        "INSERT INTO user (mail, weekdays, last_chosen, tenant_id) VALUES (?, ?, ?, ?)",
-        ("alice@example.com", "1,2,3,4,5", "2026-03-01", 1),
+        "INSERT INTO user (mail, weekdays, tenant_id) VALUES (?, ?, ?)",
+        ("alice@example.com", "1,2,3,4,5", 1),
     )
     conn.execute(
-        "INSERT INTO user (mail, weekdays, last_chosen, tenant_id) VALUES (?, ?, ?, ?)",
-        ("bob@example.com", "1,2,3,4,5", "2026-03-20", 1),
+        "INSERT INTO user (mail, weekdays, tenant_id) VALUES (?, ?, ?)",
+        ("bob@example.com", "1,2,3,4,5", 1),
     )
     conn.commit()
     yield conn
@@ -182,14 +183,14 @@ class TestGetRecentSelectionCount:
     def test_counts_recent(self, db):
         today = datetime.date.today().isoformat()
         db.execute(
-            "INSERT INTO selection_history (user_id, selected_date) VALUES (1, ?)",
+            "INSERT INTO selection_history (user_id, selected_date, tenant_id) VALUES (1, ?, 1)",
             (today,),
         )
         db.commit()
-        assert get_recent_selection_count(db, 1) >= 1
+        assert get_recent_selection_count(db, 1, tenant_id=1) >= 1
 
     def test_zero_when_none(self, db):
-        assert get_recent_selection_count(db, 1) == 0
+        assert get_recent_selection_count(db, 1, tenant_id=1) == 0
 
 
 # --- cleanup_old_selection_history ---
@@ -199,7 +200,7 @@ class TestCleanupOldSelectionHistory:
     def test_deletes_old_records(self, db):
         old = (datetime.date.today() - datetime.timedelta(days=400)).isoformat()
         db.execute(
-            "INSERT INTO selection_history (user_id, selected_date) VALUES (1, ?)",
+            "INSERT INTO selection_history (user_id, selected_date, tenant_id) VALUES (1, ?, 1)",
             (old,),
         )
         db.commit()
@@ -210,7 +211,7 @@ class TestCleanupOldSelectionHistory:
     def test_keeps_recent_records(self, db):
         recent = datetime.date.today().isoformat()
         db.execute(
-            "INSERT INTO selection_history (user_id, selected_date) VALUES (1, ?)",
+            "INSERT INTO selection_history (user_id, selected_date, tenant_id) VALUES (1, ?, 1)",
             (recent,),
         )
         db.commit()
@@ -253,15 +254,15 @@ class TestCalculateUserWeight:
 
 class TestAddTieBreakingLogic:
     def test_single_user_unchanged(self):
-        users = [{"user": {"mail": "a@b.com", "last_chosen": None}, "weight": 100}]
+        users = [{"user": {"mail": "a@b.com"}, "weight": 100, "last_selected": None}]
         result = add_tie_breaking_logic(users)
         assert len(result) == 1
         assert result[0]["weight"] == 100
 
     def test_tied_users_get_different_weights(self):
         users = [
-            {"user": {"mail": "a@b.com", "last_chosen": "2026-01-01"}, "weight": 100},
-            {"user": {"mail": "b@b.com", "last_chosen": "2026-02-01"}, "weight": 100},
+            {"user": {"mail": "a@b.com"}, "weight": 100, "last_selected": "2026-01-01"},
+            {"user": {"mail": "b@b.com"}, "weight": 100, "last_selected": "2026-02-01"},
         ]
         result = add_tie_breaking_logic(users)
         weights = [u["weight"] for u in result]
@@ -269,8 +270,8 @@ class TestAddTieBreakingLogic:
 
     def test_never_selected_wins_tie(self):
         users = [
-            {"user": {"mail": "recent@b.com", "last_chosen": "2026-03-01"}, "weight": 100},
-            {"user": {"mail": "never@b.com", "last_chosen": None}, "weight": 100},
+            {"user": {"mail": "recent@b.com"}, "weight": 100, "last_selected": "2026-03-01"},
+            {"user": {"mail": "never@b.com"}, "weight": 100, "last_selected": None},
         ]
         result = add_tie_breaking_logic(users)
         # Never-selected should get higher tie-breaker
@@ -444,7 +445,7 @@ class TestFindNextCatcherWeighted:
         today = datetime.date.today().isoformat()
         db.execute("UPDATE user SET weekdays = ?", ("0,1,2,3,4,5,6",))
         db.execute(
-            "INSERT INTO selection_history (user_id, selected_date) VALUES (1, ?)",
+            "INSERT INTO selection_history (user_id, selected_date, tenant_id) VALUES (1, ?, 1)",
             (today,),
         )
         db.commit()

--- a/tests/test_channel_id.py
+++ b/tests/test_channel_id.py
@@ -27,7 +27,6 @@ def db(tmp_path):
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             mail VARCHAR(50) UNIQUE NOT NULL,
             weekdays VARCHAR(10),
-            last_chosen DATE,
             tenant_id INTEGER REFERENCES tenants(id),
             display_name VARCHAR(100)
         );
@@ -45,7 +44,9 @@ def db(tmp_path):
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             user_id INTEGER NOT NULL,
             selected_date DATE NOT NULL,
-            FOREIGN KEY (user_id) REFERENCES user(id)
+            tenant_id INTEGER NOT NULL,
+            FOREIGN KEY (user_id) REFERENCES user(id),
+            FOREIGN KEY (tenant_id) REFERENCES tenants(id)
         );
     """)
     conn.execute(

--- a/tests/test_selection_history_tenant.py
+++ b/tests/test_selection_history_tenant.py
@@ -1,0 +1,397 @@
+"""Tests for selection_history tenant_id feature and manage_users move command."""
+
+import datetime
+import sqlite3
+
+import pytest
+from pathlib import Path
+from unittest.mock import patch
+
+from catcher import (
+    get_recent_selection_count,
+    get_last_working_day_catcher,
+)
+
+
+@pytest.fixture
+def multi_tenant_db(tmp_path):
+    """Create a DB with two tenants and users, plus selection_history with tenant_id."""
+    db_path = tmp_path / "test.db"
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+
+    schema_path = Path(__file__).parent.parent / "schema_tenants.sql"
+    conn.executescript(schema_path.read_text())
+
+    conn.executescript("""
+        CREATE TABLE IF NOT EXISTS user (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            mail VARCHAR(50) UNIQUE NOT NULL,
+            weekdays VARCHAR(10),
+            tenant_id INTEGER REFERENCES tenants(id),
+            display_name VARCHAR(100)
+        );
+        CREATE TABLE IF NOT EXISTS vacation (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INTEGER NOT NULL,
+            start_date DATE NOT NULL,
+            end_date DATE NOT NULL,
+            FOREIGN KEY (user_id) REFERENCES user(id)
+        );
+        CREATE TABLE IF NOT EXISTS selection_history (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INTEGER NOT NULL,
+            selected_date DATE NOT NULL,
+            tenant_id INTEGER NOT NULL,
+            FOREIGN KEY (user_id) REFERENCES user(id),
+            FOREIGN KEY (tenant_id) REFERENCES tenants(id)
+        );
+    """)
+
+    # Two tenants
+    conn.execute(
+        "INSERT INTO tenants (id, name, location, webhook_url, active) "
+        "VALUES (1, 'Small Team', 'BW', 'http://hook1', 1)"
+    )
+    conn.execute(
+        "INSERT INTO tenants (id, name, location, webhook_url, active) "
+        "VALUES (2, 'Big Team', 'BY', 'http://hook2', 1)"
+    )
+
+    # Alice in Small Team, Bob and Carol in Big Team (all available every day)
+    conn.execute(
+        "INSERT INTO user (id, mail, weekdays, tenant_id) VALUES (1, 'alice@example.com', '0,1,2,3,4,5,6', 1)"
+    )
+    conn.execute(
+        "INSERT INTO user (id, mail, weekdays, tenant_id) VALUES (2, 'bob@example.com', '0,1,2,3,4,5,6', 2)"
+    )
+    conn.execute(
+        "INSERT INTO user (id, mail, weekdays, tenant_id) VALUES (3, 'carol@example.com', '0,1,2,3,4,5,6', 2)"
+    )
+
+    conn.commit()
+    yield conn
+    conn.close()
+
+
+class TestFairnessIsolation:
+    """Test that selection_history.tenant_id properly isolates fairness calculations."""
+
+    def test_old_tenant_history_ignored_after_move(self, multi_tenant_db):
+        """A user moved from tenant 1 to tenant 2 should have their tenant-1 history ignored."""
+        conn = multi_tenant_db
+
+        # Alice was selected many times in Small Team
+        for i in range(20):
+            date = (datetime.date.today() - datetime.timedelta(days=i + 1)).isoformat()
+            conn.execute(
+                "INSERT INTO selection_history (user_id, selected_date, tenant_id) VALUES (1, ?, 1)",
+                (date,),
+            )
+        conn.commit()
+
+        # Move Alice to Big Team
+        conn.execute("UPDATE user SET tenant_id = 2 WHERE id = 1")
+        conn.commit()
+
+        # Alice's recent selection count for Big Team should be 0
+        count = get_recent_selection_count(conn, 1, tenant_id=2)
+        assert count == 0
+
+    def test_total_selections_scoped_to_current_tenant(self, multi_tenant_db):
+        """Total selections should only count entries for the current tenant."""
+        conn = multi_tenant_db
+
+        # Alice has 10 selections in tenant 1 and 2 in tenant 2
+        for i in range(10):
+            date = (datetime.date.today() - datetime.timedelta(days=i + 1)).isoformat()
+            conn.execute(
+                "INSERT INTO selection_history (user_id, selected_date, tenant_id) VALUES (1, ?, 1)",
+                (date,),
+            )
+        for i in range(2):
+            date = (datetime.date.today() - datetime.timedelta(days=i + 11)).isoformat()
+            conn.execute(
+                "INSERT INTO selection_history (user_id, selected_date, tenant_id) VALUES (1, ?, 2)",
+                (date,),
+            )
+        conn.commit()
+
+        # Move Alice to Big Team
+        conn.execute("UPDATE user SET tenant_id = 2 WHERE id = 1")
+        conn.commit()
+
+        # Only 2 selections count for tenant 2
+        count = get_recent_selection_count(conn, 1, tenant_id=2, days=365)
+        assert count == 2
+
+    def test_get_last_working_day_catcher_uses_tenant_id(self, multi_tenant_db):
+        """get_last_working_day_catcher should use selection_history.tenant_id."""
+        conn = multi_tenant_db
+        yesterday = (datetime.date.today() - datetime.timedelta(days=1)).isoformat()
+
+        # Alice was catcher yesterday for tenant 1
+        conn.execute(
+            "INSERT INTO selection_history (user_id, selected_date, tenant_id) VALUES (1, ?, 1)",
+            (yesterday,),
+        )
+        # Bob was catcher yesterday for tenant 2
+        conn.execute(
+            "INSERT INTO selection_history (user_id, selected_date, tenant_id) VALUES (2, ?, 2)",
+            (yesterday,),
+        )
+        conn.commit()
+
+        # Even if yesterday is a weekend day, test the concept
+        with patch("catcher.holidays.Germany") as mock_holidays:
+            mock_holidays.return_value = {}
+            last_t1 = get_last_working_day_catcher(conn, tenant_id=1)
+            last_t2 = get_last_working_day_catcher(conn, tenant_id=2)
+
+        # If yesterday was a weekday, these should be correct
+        # (if weekend, both will be None which is also valid)
+        if datetime.date.today().weekday() not in (0, 6):
+            # yesterday was not weekend (today is not Mon or Sun)
+            assert last_t1 == 1
+            assert last_t2 == 2
+
+
+class TestMoveBackHistory:
+    """Test that moving back to a previous tenant restores history context."""
+
+    def test_history_restored_on_move_back(self, multi_tenant_db):
+        """When a user moves A→B→A, their tenant-A history is visible again."""
+        conn = multi_tenant_db
+
+        # Alice has history in tenant 1
+        for i in range(5):
+            date = (datetime.date.today() - datetime.timedelta(days=i + 1)).isoformat()
+            conn.execute(
+                "INSERT INTO selection_history (user_id, selected_date, tenant_id) VALUES (1, ?, 1)",
+                (date,),
+            )
+        conn.commit()
+
+        # Move to tenant 2 — no history there
+        conn.execute("UPDATE user SET tenant_id = 2 WHERE id = 1")
+        conn.commit()
+        count_in_2 = get_recent_selection_count(conn, 1, tenant_id=2)
+        assert count_in_2 == 0
+
+        # Move back to tenant 1 — history is back
+        conn.execute("UPDATE user SET tenant_id = 1 WHERE id = 1")
+        conn.commit()
+        count_in_1 = get_recent_selection_count(conn, 1, tenant_id=1)
+        assert count_in_1 == 5
+
+
+class TestMigration:
+    """Test the migration script logic."""
+
+    def test_migration_adds_tenant_id_and_drops_last_chosen(self, tmp_path):
+        """Test that migration adds tenant_id, backfills, and drops last_chosen."""
+        db_path = tmp_path / "test.db"
+        conn = sqlite3.connect(db_path)
+
+        # Create pre-migration schema
+        schema_path = Path(__file__).parent.parent / "schema_tenants.sql"
+        conn.executescript(schema_path.read_text())
+        conn.executescript("""
+            CREATE TABLE user (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                mail VARCHAR(50) UNIQUE NOT NULL,
+                weekdays VARCHAR(10),
+                last_chosen DATE,
+                tenant_id INTEGER REFERENCES tenants(id)
+            );
+            CREATE TABLE selection_history (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id INTEGER NOT NULL,
+                selected_date DATE NOT NULL,
+                FOREIGN KEY (user_id) REFERENCES user(id)
+            );
+        """)
+        conn.execute(
+            "INSERT INTO tenants (id, name, location, webhook_url, active) "
+            "VALUES (1, 'Team A', 'BW', 'http://hook', 1)"
+        )
+        conn.execute(
+            "INSERT INTO user (id, mail, weekdays, last_chosen, tenant_id) "
+            "VALUES (1, 'a@b.com', '1,2,3', '2026-01-01', 1)"
+        )
+        conn.execute(
+            "INSERT INTO selection_history (user_id, selected_date) VALUES (1, '2026-01-01')"
+        )
+        conn.commit()
+        conn.close()
+
+        # Run migration
+        with (
+            patch("migrate_selection_history_tenant.DATABASE_PATH", str(db_path)),
+            patch("db.DATABASE_PATH", str(db_path)),
+        ):
+            from migrate_selection_history_tenant import main
+
+            main()
+
+        # Verify result
+        conn = sqlite3.connect(db_path)
+        conn.row_factory = sqlite3.Row
+
+        # tenant_id is backfilled
+        row = conn.execute(
+            "SELECT tenant_id FROM selection_history WHERE id = 1"
+        ).fetchone()
+        assert row["tenant_id"] == 1
+
+        # last_chosen is gone
+        cols = [r[1] for r in conn.execute("PRAGMA table_info(user)").fetchall()]
+        assert "last_chosen" not in cols
+
+        # Index exists
+        indexes = [
+            r[1]
+            for r in conn.execute(
+                "SELECT * FROM sqlite_master WHERE type='index' AND tbl_name='selection_history'"
+            ).fetchall()
+        ]
+        assert "idx_selection_history_tenant_date" in indexes
+
+        conn.close()
+
+    def test_migration_is_idempotent(self, tmp_path):
+        """Running migration twice should not error."""
+        db_path = tmp_path / "test.db"
+        conn = sqlite3.connect(db_path)
+
+        schema_path = Path(__file__).parent.parent / "schema_tenants.sql"
+        conn.executescript(schema_path.read_text())
+        conn.executescript("""
+            CREATE TABLE user (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                mail VARCHAR(50) UNIQUE NOT NULL,
+                weekdays VARCHAR(10),
+                last_chosen DATE,
+                tenant_id INTEGER REFERENCES tenants(id)
+            );
+            CREATE TABLE selection_history (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id INTEGER NOT NULL,
+                selected_date DATE NOT NULL,
+                FOREIGN KEY (user_id) REFERENCES user(id)
+            );
+        """)
+        conn.execute(
+            "INSERT INTO tenants (id, name, location, webhook_url, active) "
+            "VALUES (1, 'Team A', 'BW', 'http://hook', 1)"
+        )
+        conn.execute(
+            "INSERT INTO user (id, mail, weekdays, tenant_id) "
+            "VALUES (1, 'a@b.com', '1,2,3', 1)"
+        )
+        conn.commit()
+        conn.close()
+
+        with (
+            patch("migrate_selection_history_tenant.DATABASE_PATH", str(db_path)),
+            patch("db.DATABASE_PATH", str(db_path)),
+        ):
+            from migrate_selection_history_tenant import main
+
+            main()
+            # Second run should not raise
+            main()
+
+        conn = sqlite3.connect(db_path)
+        cols = [r[1] for r in conn.execute("PRAGMA table_info(user)").fetchall()]
+        assert "last_chosen" not in cols
+        conn.close()
+
+
+class TestManageUsersMove:
+    """Test the move command in manage_users.py."""
+
+    @pytest.fixture
+    def move_db(self, tmp_path):
+        db_path = tmp_path / "test.db"
+        conn = sqlite3.connect(db_path)
+        conn.execute("""
+            CREATE TABLE tenants (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name VARCHAR(100) UNIQUE NOT NULL,
+                location VARCHAR(10) NOT NULL,
+                webhook_url VARCHAR(500) NOT NULL,
+                active BOOLEAN DEFAULT 1
+            )
+        """)
+        conn.execute("""
+            CREATE TABLE user (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                mail VARCHAR(50) UNIQUE NOT NULL,
+                weekdays VARCHAR(10),
+                tenant_id INTEGER REFERENCES tenants(id),
+                display_name VARCHAR(100)
+            )
+        """)
+        conn.execute(
+            "INSERT INTO tenants (id, name, location, webhook_url) VALUES (1, 'Team A', 'BW', 'http://a')"
+        )
+        conn.execute(
+            "INSERT INTO tenants (id, name, location, webhook_url) VALUES (2, 'Team B', 'BY', 'http://b')"
+        )
+        conn.execute(
+            "INSERT INTO user (id, mail, weekdays, tenant_id) VALUES (1, 'alice@example.com', '1,2,3,4,5', 1)"
+        )
+        conn.commit()
+        conn.close()
+        return db_path
+
+    def test_move_user_to_new_tenant(self, move_db, capsys):
+        from manage_users import cmd_move
+        import argparse
+
+        args = argparse.Namespace(
+            identifier="alice@example.com", tenant="Team B", db=str(move_db)
+        )
+        cmd_move(args)
+
+        conn = sqlite3.connect(move_db)
+        row = conn.execute("SELECT tenant_id FROM user WHERE id = 1").fetchone()
+        assert row[0] == 2
+        conn.close()
+
+        output = capsys.readouterr().out
+        assert "Team A" in output
+        assert "Team B" in output
+
+    def test_move_user_already_in_tenant(self, move_db, capsys):
+        from manage_users import cmd_move
+        import argparse
+
+        args = argparse.Namespace(
+            identifier="alice@example.com", tenant="Team A", db=str(move_db)
+        )
+        cmd_move(args)
+
+        output = capsys.readouterr().out
+        assert "already in tenant" in output
+
+    def test_move_user_not_found(self, move_db):
+        from manage_users import cmd_move
+        import argparse
+
+        args = argparse.Namespace(
+            identifier="nobody@example.com", tenant="Team B", db=str(move_db)
+        )
+        with pytest.raises(SystemExit):
+            cmd_move(args)
+
+    def test_move_tenant_not_found(self, move_db):
+        from manage_users import cmd_move
+        import argparse
+
+        args = argparse.Namespace(
+            identifier="alice@example.com", tenant="Nonexistent", db=str(move_db)
+        )
+        with pytest.raises(SystemExit):
+            cmd_move(args)

--- a/tests/test_takeover.py
+++ b/tests/test_takeover.py
@@ -151,21 +151,20 @@ class TestTakeoverApp:
         assert row[0] == 2
         conn.close()
 
-    def test_takeover_resets_previous_catcher(self, client, db):
+    def test_takeover_replaces_selection(self, client, db):
         today = datetime.date.today().isoformat()
         yesterday = (datetime.date.today() - datetime.timedelta(days=1)).isoformat()
 
         # Set up: alice was selected today, had a prior selection yesterday
         conn = sqlite3.connect(db)
         conn.execute(
-            "INSERT INTO selection_history (user_id, selected_date) VALUES (1, ?)",
+            "INSERT INTO selection_history (user_id, selected_date, tenant_id) VALUES (1, ?, 1)",
             (yesterday,),
         )
         conn.execute(
-            "INSERT INTO selection_history (user_id, selected_date) VALUES (1, ?)",
+            "INSERT INTO selection_history (user_id, selected_date, tenant_id) VALUES (1, ?, 1)",
             (today,),
         )
-        conn.execute("UPDATE user SET last_chosen = ? WHERE id = 1", (today,))
         conn.commit()
         conn.close()
 
@@ -174,13 +173,13 @@ class TestTakeoverApp:
         resp = client.get(f"/takeover?tenant=1&nonce={nonce}&uid=bob.smith")
         assert resp.status_code == 200
 
-        # Verify alice's last_chosen was reset to yesterday
+        # Verify bob is now today's catcher
         conn = sqlite3.connect(db)
-        alice = conn.execute("SELECT last_chosen FROM user WHERE id = 1").fetchone()
-        assert alice[0] == yesterday
-        # Bob is now today's catcher
-        bob = conn.execute("SELECT last_chosen FROM user WHERE id = 2").fetchone()
-        assert bob[0] == today
+        row = conn.execute(
+            "SELECT user_id FROM selection_history WHERE selected_date = ? AND tenant_id = 1",
+            (today,),
+        ).fetchone()
+        assert row[0] == 2
         conn.close()
 
     def test_second_takeover_same_day_returns_409(self, client, db):

--- a/tests/test_tenant_parameter.py
+++ b/tests/test_tenant_parameter.py
@@ -45,7 +45,6 @@ def test_db_with_tenants(tmp_path):
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             mail VARCHAR(50) UNIQUE NOT NULL,
             weekdays VARCHAR(10),
-            last_chosen DATE,
             tenant_id INTEGER REFERENCES tenants(id)
         )
     """)

--- a/tests/test_tenant_user_filtering.py
+++ b/tests/test_tenant_user_filtering.py
@@ -42,7 +42,6 @@ def test_db_with_tenant_users(tmp_path):
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             mail VARCHAR(50) UNIQUE NOT NULL,
             weekdays VARCHAR(10),
-            last_chosen DATE,
             tenant_id INTEGER REFERENCES tenants(id)
         )
     """)
@@ -62,7 +61,8 @@ def test_db_with_tenant_users(tmp_path):
         CREATE TABLE selection_history (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             user_id INTEGER REFERENCES user(id),
-            selected_date DATE
+            selected_date DATE,
+            tenant_id INTEGER NOT NULL
         )
     """)
 
@@ -220,8 +220,8 @@ def test_selection_history_scoped_per_tenant(test_db_with_tenant_users):
 
     # Add selection history for alpha1 today
     conn.execute(
-        "INSERT INTO selection_history (user_id, selected_date) VALUES (?, ?)",
-        (1, today),
+        "INSERT INTO selection_history (user_id, selected_date, tenant_id) VALUES (?, ?, ?)",
+        (1, today, 1),
     )
     conn.commit()
 

--- a/tests/test_vacation_sync.py
+++ b/tests/test_vacation_sync.py
@@ -23,7 +23,6 @@ def db_path(tmp_path):
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             mail VARCHAR(50) UNIQUE NOT NULL,
             weekdays VARCHAR(10),
-            last_chosen DATE,
             tenant_id INTEGER REFERENCES tenants(id),
             display_name VARCHAR(100)
         );

--- a/tests/test_vacation_validation.py
+++ b/tests/test_vacation_validation.py
@@ -16,8 +16,7 @@ def db_with_vacation(tmp_path):
         CREATE TABLE user (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             mail VARCHAR(50) UNIQUE NOT NULL,
-            weekdays VARCHAR(10),
-            last_chosen DATE
+            weekdays VARCHAR(10)
         )
     """)
     conn.execute("""

--- a/user_statistics.py
+++ b/user_statistics.py
@@ -14,19 +14,22 @@ def get_user_statistics(tenant_name=None):
     cursor = conn.cursor()
 
     if tenant_name:
-        cursor.execute("""
+        cursor.execute(
+            """
             SELECT
                 t.name as tenant_name,
                 u.mail,
                 COUNT(sh.id) as total_selections,
                 MAX(sh.selected_date) as last_selection
             FROM user u
-            LEFT JOIN selection_history sh ON u.id = sh.user_id
             LEFT JOIN tenants t ON u.tenant_id = t.id
+            LEFT JOIN selection_history sh ON u.id = sh.user_id AND sh.tenant_id = t.id
             WHERE t.name = ?
             GROUP BY u.tenant_id, u.id, u.mail
             ORDER BY total_selections DESC
-        """, (tenant_name,))
+        """,
+            (tenant_name,),
+        )
     else:
         cursor.execute("""
             SELECT
@@ -35,8 +38,8 @@ def get_user_statistics(tenant_name=None):
                 COUNT(sh.id) as total_selections,
                 MAX(sh.selected_date) as last_selection
             FROM user u
-            LEFT JOIN selection_history sh ON u.id = sh.user_id
             LEFT JOIN tenants t ON u.tenant_id = t.id
+            LEFT JOIN selection_history sh ON u.id = sh.user_id AND sh.tenant_id = t.id
             GROUP BY u.tenant_id, u.id, u.mail
             ORDER BY t.name, total_selections DESC
         """)
@@ -55,7 +58,7 @@ def get_user_statistics(tenant_name=None):
         print(f"{'Email':<40} {'Selections':<12} {'%':<8} {'Last':<12}")
         print("-" * 77)
         for mail, selections, last in users:
-            pct = f"{selections/total*100:.1f}" if total > 0 else "0.0"
+            pct = f"{selections / total * 100:.1f}" if total > 0 else "0.0"
             print(f"{mail:<40} {selections:<12} {pct:<8} {last or 'N/A':<12}")
 
 


### PR DESCRIPTION
## Summary

Scope all fairness calculations to the current tenant via `selection_history.tenant_id`. Users who move between tenants get a clean slate in the new team while preserving history if they move back.

## Changes

- Add `tenant_id NOT NULL` column to `selection_history` with FK to `tenants`
- Remove `user.last_chosen` (derived from `MAX(selected_date)` per tenant)
- Add idempotent migration script `migrate_selection_history_tenant.py`
- Add `move` command to `manage_users.py`
- Simplify `takeover_app.py` queries (no more JOIN for tenant scoping)
- Update `user_statistics.py` and `manage_vacations.py` for new schema

## Migration

```bash
uv run migrate_selection_history_tenant.py
```

Backfills `tenant_id` from current `user.tenant_id`. If any user has already moved between tenants, manually fix their old rows afterward.

## Testing

- 195 tests pass (10 new covering fairness isolation, move-back semantics, migration, and move command)
- `ruff check` clean