### PR TITLE
Fix Docker package description on GitHub Packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 FROM ghcr.io/astral-sh/uv:python3.13-bookworm-slim
 
+LABEL org.opencontainers.image.title="cotd-takeover"
+LABEL org.opencontainers.image.description="Catcher of the Day - Takeover web app"
+LABEL org.opencontainers.image.source="https://github.com/ujaehrig/cotd"
+
 WORKDIR /app
 
 COPY takeover_app.py db.py ./


### PR DESCRIPTION
Add OCI labels to override the uv base image metadata.