### PR TITLE
Add lefthook hooks and fix ty type errors

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,34 @@
+name: Auto Release
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'pyproject.toml'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Check version change
+        id: version
+        run: |
+          current=$(grep '^version' pyproject.toml | sed 's/.*"\(.*\)"/\1/')
+          previous=$(git show HEAD~1:pyproject.toml 2>/dev/null | grep '^version' | sed 's/.*"\(.*\)"/\1/' || echo "")
+          if [ "$current" != "$previous" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "tag=v${current}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create release
+        if: steps.version.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release create "${{ steps.version.outputs.tag }}" --generate-notes

--- a/catcher.py
+++ b/catcher.py
@@ -304,7 +304,7 @@ def is_weekend() -> bool:
     return datetime.datetime.now().weekday() >= 5  # 5 = Saturday, 6 = Sunday
 
 
-def is_holiday(location: str = None) -> bool:
+def is_holiday(location: str | None = None) -> bool:
     """
     Check if today is a public holiday in Germany.
     First tries the web service API, then falls back to the holidays library.
@@ -339,7 +339,7 @@ def is_holiday(location: str = None) -> bool:
     # Fallback to holidays library
     try:
         # Create holidays object for Germany with specified subdivision
-        german_holidays = holidays.Germany(subdiv=location)
+        german_holidays = holidays.country_holidays("DE", subdiv=location)
         today = datetime.date.today()
 
         if today in german_holidays:
@@ -506,7 +506,7 @@ def is_user_on_vacation(conn: sqlite3.Connection, user_id: int, date: str) -> bo
 
 
 def get_last_working_day_catcher(
-    conn: sqlite3.Connection, tenant_id: int = None
+    conn: sqlite3.Connection, tenant_id: int | None = None
 ) -> Optional[int]:
     """
     Get the user ID of the last working day's catcher (skipping weekends and holidays).
@@ -532,7 +532,7 @@ def get_last_working_day_catcher(
             # Check if it was a holiday
             try:
                 # Check with holidays library
-                german_holidays = holidays.Germany(subdiv=HOLIDAY_REGION)
+                german_holidays = holidays.country_holidays("DE", subdiv=HOLIDAY_REGION)
                 if check_date in german_holidays:
                     continue
             except Exception:
@@ -573,7 +573,7 @@ def get_last_working_day_catcher(
 def get_recent_selection_count(
     conn: sqlite3.Connection,
     user_id: int,
-    tenant_id: int = None,
+    tenant_id: int | None = None,
     days: int = LOOKBACK_DAYS,
 ) -> int:
     """
@@ -790,8 +790,8 @@ def calculate_user_weight(
 
 
 def find_next_catcher(
-    conn: sqlite3.Connection = None,
-    tenant_id: int = None,
+    conn: sqlite3.Connection | None = None,
+    tenant_id: int | None = None,
     dry_run: bool = False,
     debug_weights: bool = False,
 ) -> Tuple[Optional[str], bool]:

--- a/db.py
+++ b/db.py
@@ -7,7 +7,7 @@ from pathlib import Path
 DATABASE_PATH = os.environ.get("DB_PATH", str(Path(__file__).parent / "user.db"))
 
 
-def get_db_connection(db_path: str = None) -> sqlite3.Connection:
+def get_db_connection(db_path: str | None = None) -> sqlite3.Connection:
     """
     Create and return a database connection with Row factory.
 

--- a/ical_sync.py
+++ b/ical_sync.py
@@ -29,7 +29,7 @@ logger = logging.getLogger(__name__)
 class ICalParser:
     """Fetches and parses iCal/ICS calendar feeds."""
 
-    def __init__(self, timeout: int = None):
+    def __init__(self, timeout: int | None = None):
         """
         Initialize the iCal parser.
 
@@ -60,7 +60,7 @@ class ICalParser:
             logger.error(f"Error fetching calendar from {safe_url}: {e}")
             return None
 
-    def extract_events(self, calendar: Calendar, start_date: date = None) -> List[Dict]:
+    def extract_events(self, calendar: Calendar, start_date: date | None = None) -> List[Dict]:
         """
         Extract vacation events from calendar.
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,17 @@
+pre-commit:
+  parallel: true
+  commands:
+    lint:
+      glob: "*.py"
+      run: uv run ruff check {staged_files}
+    format:
+      glob: "*.py"
+      run: uv run ruff format --check {staged_files}
+    typecheck:
+      glob: "*.py"
+      run: uv run ty check {staged_files}
+
+pre-push:
+  commands:
+    test:
+      run: uv run pytest

--- a/migrate_ical_support.py
+++ b/migrate_ical_support.py
@@ -20,7 +20,7 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 
-def migrate_database(db_path: str = None) -> None:
+def migrate_database(db_path: str | None = None) -> None:
     """
     Migrate database to support iCal vacation sync.
 

--- a/migrate_to_tenants.py
+++ b/migrate_to_tenants.py
@@ -22,7 +22,7 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 
-def migrate_database(db_path: str = None) -> None:
+def migrate_database(db_path: str | None = None) -> None:
     """
     Migrate database to support multi-tenant architecture.
 

--- a/migrate_vacation_upsert.py
+++ b/migrate_vacation_upsert.py
@@ -25,7 +25,7 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 
-def migrate_database(db_path: str = None) -> None:
+def migrate_database(db_path: str | None = None) -> None:
     """Add UNIQUE(user_id, ical_event_uid) to vacation table."""
     if db_path is None:
         from db import DATABASE_PATH

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cotd"
-version = "0.1.0"
+version = "1.2.0"
 description = "Catcher of the Day - Slack-based daily catcher selection"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -17,6 +17,7 @@ dev = [
     "flask>=3.1.3",
     "pytest>=9.0.2",
     "pytest-cov>=7.1.0",
+    "ty>=0.0.55",
 ]
 
 [tool.pytest.ini_options]

--- a/tests/test_channel_id.py
+++ b/tests/test_channel_id.py
@@ -68,10 +68,12 @@ def db(tmp_path):
 class TestTenantChannelId:
     def test_get_tenant_by_name_includes_channel_id(self, db):
         tenant = get_tenant_by_name(db, "Team Alpha")
+        assert tenant is not None
         assert tenant["slack_channel_id"] == "C12345"
 
     def test_get_tenant_by_name_channel_id_null(self, db):
         tenant = get_tenant_by_name(db, "Team Beta")
+        assert tenant is not None
         assert tenant["slack_channel_id"] is None
 
     def test_get_active_tenants_includes_channel_id(self, db):
@@ -118,6 +120,7 @@ class TestProcessTenantChannelId:
         self, mock_holiday, mock_weekend, mock_trigger, db
     ):
         tenant = get_tenant_by_name(db, "Team Beta")
+        assert tenant is not None
         process_tenant(db, tenant)
         mock_trigger.assert_not_called()
 
@@ -128,6 +131,7 @@ class TestProcessTenantChannelId:
         self, mock_holiday, mock_weekend, mock_trigger, db
     ):
         tenant = get_tenant_by_name(db, "Team Alpha")
+        assert tenant is not None
         process_tenant(db, tenant)
         mock_trigger.assert_called_once()
         call_kwargs = mock_trigger.call_args.kwargs

--- a/tests/test_tenant_parameter.py
+++ b/tests/test_tenant_parameter.py
@@ -129,6 +129,7 @@ def test_process_tenant_returns_success(test_db_with_tenants):
 
     conn = sqlite3.connect(test_db_with_tenants)
     tenant = get_tenant_by_name(conn, "Team Alpha")
+    assert tenant is not None
 
     # Mock external dependencies
     with (
@@ -157,6 +158,7 @@ def test_process_tenant_handles_weekend(test_db_with_tenants):
 
     conn = sqlite3.connect(test_db_with_tenants)
     tenant = get_tenant_by_name(conn, "Team Alpha")
+    assert tenant is not None
 
     with patch("catcher.is_weekend", return_value=True):
         from catcher import process_tenant
@@ -176,6 +178,7 @@ def test_process_tenant_handles_errors(test_db_with_tenants):
 
     conn = sqlite3.connect(test_db_with_tenants)
     tenant = get_tenant_by_name(conn, "Team Alpha")
+    assert tenant is not None
 
     with patch("catcher.is_weekend", side_effect=Exception("Test error")):
         from catcher import process_tenant

--- a/user_matcher.py
+++ b/user_matcher.py
@@ -12,14 +12,14 @@ User matching module for fuzzy matching calendar event names to users.
 
 import os
 import re
-from typing import Optional, List, Tuple
+from typing import Optional, List, Tuple, Sequence
 from rapidfuzz import fuzz
 
 
 class UserMatcher:
     """Matches names from calendar events to users using fuzzy matching."""
 
-    def __init__(self, threshold: int = None):
+    def __init__(self, threshold: int | None = None):
         """
         Initialize the user matcher.
 
@@ -61,7 +61,7 @@ class UserMatcher:
     def match_user(
         self,
         event_title: str,
-        users: List[Tuple[int, str, Optional[str]]]
+        users: Sequence[Tuple[int, str, Optional[str]]]
     ) -> Optional[int]:
         """
         Match event title to a user.

--- a/uv.lock
+++ b/uv.lock
@@ -115,6 +115,7 @@ dev = [
     { name = "flask" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "ty" },
 ]
 
 [package.metadata]
@@ -131,6 +132,7 @@ dev = [
     { name = "flask", specifier = ">=3.1.3" },
     { name = "pytest", specifier = ">=9.0.2" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
+    { name = "ty", specifier = ">=0.0.55" },
 ]
 
 [[package]]
@@ -487,6 +489,31 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "ty"
+version = "0.0.55"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/08/48/f687c8d268e3581f2f104d1f2ac5944d5b5e841b3695c613b3f263e5bbf7/ty-0.0.55.tar.gz", hash = "sha256:88ca87073825a79a8327c550efcc86cec94344890244c5946f84c9e44a969f31", size = 6040230, upload-time = "2026-06-27T00:27:29.385Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/a3/1a90ba7e5a61c6d09adb92346ddba97668095fc257b577af433e5ac4f404/ty-0.0.55-py3-none-linux_armv6l.whl", hash = "sha256:31e83eef512d066542fe990fe1a3b814423abd1616376c54e48af7045b3e1749", size = 11677249, upload-time = "2026-06-27T00:26:52.18Z" },
+    { url = "https://files.pythonhosted.org/packages/82/3a/669f9aa478c38243e213a2684db1502086026cfadc15bb1b29b7cbde030d/ty-0.0.55-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ab4bca857950608fea73e269e2da369d43e6467131de85160d68e2fa466fa248", size = 11444180, upload-time = "2026-06-27T00:26:54.576Z" },
+    { url = "https://files.pythonhosted.org/packages/15/a4/6a4b2507a53ce6530c66c5b4fe0d58551eb1748ffa9e0696c32fdd55bbd4/ty-0.0.55-py3-none-macosx_11_0_arm64.whl", hash = "sha256:55032bfd31bf2c5355ee81bdc6407b144a1cc7ee41e5681dd1368e4cef2ba327", size = 10963134, upload-time = "2026-06-27T00:26:57.348Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/ae/a3b1a0f1cc83b7d258662cb98aa80a720c2e671d0e8fa0d17a4d5d057a7a/ty-0.0.55-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ef1e049f69ce65b3c269af67624607f435e1c32319786c1e453ef9611502f295", size = 11493517, upload-time = "2026-06-27T00:26:59.26Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/9f/311ce39065a979ef40a9b847f685c8e02464e53adf1671e081eea90640ca/ty-0.0.55-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:631409975c681d5a280fc5a99b7b32e9e801f33be7567c6b42ec331362f59d7d", size = 11460590, upload-time = "2026-06-27T00:27:01.425Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/8f/3bf29aa77bd78aae48275153135a2052fa7d3ccdf1ecabeb99c8773abd66/ty-0.0.55-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e08cb0436e68b9351555ae8f2697138c9009b4d5b4ae4272232988b2a431a98f", size = 12098430, upload-time = "2026-06-27T00:27:03.596Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/6e/e88411a88240b94640bba06fb6d0d92b247fbeef47ee2bc71f39e58c2558/ty-0.0.55-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:16c215ad9f823829409b94ee188cfaa4563f6e1384f6ce3fecb1db75f6c7cf7c", size = 12673086, upload-time = "2026-06-27T00:27:05.589Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/7e/8f1762fb7f9245a68ba5ae338d73c59403ce57554e5d311b8bb55027b0ec/ty-0.0.55-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b510eb8f4032baf11b7aee2f1d53babc3b4ca03939b9cdcf6a9d15761d575188", size = 12242559, upload-time = "2026-06-27T00:27:07.714Z" },
+    { url = "https://files.pythonhosted.org/packages/72/1f/143657daf2670d977dac83435f1fe03d4843efb798d8e1e75950e541aadd/ty-0.0.55-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0ddc05e7959709c3b9b83aa627128a80446865e3c1a4882638dcff6d776dc34a", size = 12021409, upload-time = "2026-06-27T00:27:09.881Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/30/69487c439dd1fad3a4a3d96f0a472193de297eaba6fc4b8ea687ce434ac2/ty-0.0.55-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:636e8e5078787b8c6916c94e1406719f10189a4ca6b37b813a5922ce5857a8c7", size = 12303807, upload-time = "2026-06-27T00:27:11.986Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/ca/cd88b6493dafc7db077f5e17c0438eb3af6e2d6d08f616dbb52a8ddfd567/ty-0.0.55-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:ef7d6deaacb73fec603666b5471f1dc5a5699aa84e11a6d4d644dd07ca72121e", size = 11441263, upload-time = "2026-06-27T00:27:14.087Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/fe/66b6915671653ab739f71e4f1b0528e69da64429b7ebf3840c625b6e43f2/ty-0.0.55-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:9aeea0fe5875d3cf37faf0e44d0fdf9669335467749741b8fc0103916fb5cd32", size = 11484584, upload-time = "2026-06-27T00:27:16.311Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/4f/7a9c0bbac8b899e9f6c0ec110c6612f52e4db35f6bb17ddc0ef60384fa3e/ty-0.0.55-py3-none-musllinux_1_2_i686.whl", hash = "sha256:0b699c01310dbd2705a07c97c5f4aaeedef61bd9adeea2e7c46aed32401d3576", size = 11759309, upload-time = "2026-06-27T00:27:18.471Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/de/b6f8b1b69aa631b5716ef3f985c3b56de0e46c2499cc00d30c402b41f714/ty-0.0.55-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:32cbeba543e46de2a983ec6d525d8b56514f7422bd1e1b57c44ccf7bfa72c38a", size = 12128755, upload-time = "2026-06-27T00:27:20.55Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/90/a912531e51ee7e076b42972479290fa687c0f5e747b7e773f3033164acaa/ty-0.0.55-py3-none-win32.whl", hash = "sha256:52b968e24eb4f7a5c3bd251db1f99f60dd385890356d38fc619d84f1b423446a", size = 11117501, upload-time = "2026-06-27T00:27:22.714Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/7a/99d59843bf8908a7f9f4d13fda107dbad07b7faa28ecd7860eacf363fb1c/ty-0.0.55-py3-none-win_amd64.whl", hash = "sha256:bf39cbfdc0add44d94bd3fff1f53c351418d134b6a66b87efdb7876d7b7a2224", size = 12150106, upload-time = "2026-06-27T00:27:24.881Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/44/20987505cedf2a865b08482f0eabc181fd9599b062964057ec8a128a4296/ty-0.0.55-py3-none-win_arm64.whl", hash = "sha256:f7f3700a9a060e8f1af11e4fb63fafcaf272b041781f4ccdfda2b3b5c6c1e439", size = 11560157, upload-time = "2026-06-27T00:27:27.332Z" },
 ]
 
 [[package]]

--- a/vacation_sync.py
+++ b/vacation_sync.py
@@ -30,7 +30,7 @@ logger = logging.getLogger(__name__)
 class VacationSync:
     """Orchestrates vacation synchronization from iCal feeds."""
 
-    def __init__(self, db_path: str = None):
+    def __init__(self, db_path: str | None = None):
         """
         Initialize vacation sync.
 


### PR DESCRIPTION
## Summary

Add pre-commit/pre-push git hooks via lefthook and resolve all ty type-checking errors.

## Changes

- **lefthook.yml**: ruff check, ruff format --check, ty check (parallel pre-commit); pytest (pre-push)
- Fix 23 ty errors across 10 files:
  - `param: X = None` → `param: X | None = None`
  - `holidays.Germany()` → `holidays.country_holidays("DE", ...)`
  - `List` → `Sequence` for covariant parameter in user_matcher.py
  - Type narrowing assertions in tests
- Bump version to 1.2.0

## Verification

- `uv run ty check` → All checks passed
- `uv run pytest` → 195 tests passed